### PR TITLE
fix: Conditionally disable optimizeCss in development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const nextConfig = {
     ],
   },
   experimental: {
-    optimizeCss: true,
+    optimizeCss: process.env.NODE_ENV === 'production',
     optimizePackageImports: ['@radix-ui/react-icons', '@tabler/icons-react', 'lucide-react'],
   },
 };


### PR DESCRIPTION
The experimental `optimizeCss` feature in Next.js was causing styles to be broken in your development environment. This was likely due to how CSS optimization (possibly using Critters) interacted with Tailwind CSS's JIT compilation or Hot Module Replacement (HMR) in development.

This commit modifies `next.config.js` to enable `optimizeCss` only when `process.env.NODE_ENV === 'production'`. This ensures that your development mode runs without this optimization, allowing styles to load correctly, while production builds still benefit from CSS optimization.

This addresses the issue where styles were broken in development but worked correctly after a production build.